### PR TITLE
Fix error in overloading getproperty(AbstractArray, ...)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.2'
-          - '1.5'
+          - '1.10'
           - '1'
           - 'nightly'
         os:
@@ -34,10 +34,10 @@ jobs:
           - {os: 'macos-latest', arch: 'x86'}
           # Reduce number of runs on older versions
           - {os: 'windows-latest', version: '1.2'}
-          - {os: 'windows-latest', version: '1.5'}
+          - {os: 'windows-latest', version: '1.10'}
           - {os: 'windows-latest', version: 'latest'}
           - {os: 'macos-latest', version: '1.2'}
-          - {os: 'macos-latest', version: '1.5'}
+          - {os: 'macos-latest', version: '1.10'}
           - {os: 'macos-latest', version: 'latest'}
           # Don't bother with x86 on nightly
           - {os: 'ubuntu-latest', version: 'nightly', arch: 'x86'}

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ a `FDSNStationXML` document or a `Network`.
 
 ### Dot-access to arrays of objects
 
+
+**Note: `getproperty` access for arrays of these objects is deprecated and will be
+removed in a future version.**
+
 The module defines `getproperty` methods for conveniently accessing the fields of each member
 of arrays of `Network`s, `Station`s and `Channel`s.  So our previous example of finding all
 the station codes could actually have been done like this:


### PR DESCRIPTION
In the package, we add methods to `Base.getproperty` for
`AbstractArray`s of types we own in StationXML.jl.  Up until now
this hasn't caused any problems, even if it may be type piracy.

However as of Julia v1.11, `Array` is now a Julia type and as such
`getproperty(::Array, ::Symbol)` is defined, which breaks the code
here.  See https://github.com/JuliaLang/julia/issues/56100 for
details.

Update the existing `getproperty(::AbstractArray, ::Symbol)`
methods and add new ones for `Array` to overcome this problem.

These methods will be removed in future to avoid type-piracy.
