### PR TITLE
CI: Fix issue of trying to run x64 on macos-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,30 +18,29 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.2'
           - '1.10'
           - '1'
           - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x86
           - x64
         exclude:
-          # No macOS on x86
-          - {os: 'macos-latest', arch: 'x86'}
-          # Reduce number of runs on older versions
-          - {os: 'windows-latest', version: '1.2'}
-          - {os: 'windows-latest', version: '1.10'}
-          - {os: 'windows-latest', version: 'latest'}
-          - {os: 'macos-latest', version: '1.2'}
-          - {os: 'macos-latest', version: '1.10'}
-          - {os: 'macos-latest', version: 'latest'}
           # Don't bother with x86 on nightly
           - {os: 'ubuntu-latest', version: 'nightly', arch: 'x86'}
           - {os: 'windows-latest', version: 'nightly', arch: 'x86'}
+        include:
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
+          - os: macos-latest
+            version: '1.10'
+            arch: aarch64
+          - os: macos-latest
+            version: 'nightly'
+            arch: aarch64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
macOS runners on GitHub Actions are of course now aarch64 in terms
of architecture, but we had not updated CI to recognise this.
